### PR TITLE
Switching to audio extension by checking the metadata

### DIFF
--- a/src/provider/Navigation/functions/getVersification.ts
+++ b/src/provider/Navigation/functions/getVersification.ts
@@ -18,18 +18,36 @@ export const getVersification = async (
     return;
   }
 
-  const versificationUri = vscode.Uri.joinPath(
-    workspaceRootUri,
-    'audio',
-    'ingredients',
-    'versification.json',
+  if (metadata.type.flavorType.flavor.name !== 'audioTranslation') {
+    vscode.window.showErrorMessage(
+      'Audio metadata not found. Please open valid audio project or create new audio project',
+    );
+    return;
+  }
+
+  // Reading the versification path from metadata
+  const versificationPath = Object.keys(metadata.ingredients).find((key) =>
+    key.includes('versification.json'),
   );
+
+  const pathArray =
+    versificationPath && versificationPath.split(/[(\\)?(\/)?]/);
+
+  const versificationUri =
+    pathArray && pathArray.length > 0
+      ? vscode.Uri.joinPath(workspaceRootUri, ...pathArray)
+      : vscode.Uri.joinPath(
+          workspaceRootUri,
+          'audio',
+          'ingredients',
+          'versification.json',
+        );
 
   const versificationJson =
     await vscode.workspace.fs.readFile(versificationUri);
   if (!versificationJson) {
     vscode.window.showErrorMessage(
-      'Versification not found. Please open valid audio workspace or creare new audio project',
+      'Versification not found. Please open valid audio workspace or create new audio project',
     );
     return;
   }

--- a/src/utils/getMeta.ts
+++ b/src/utils/getMeta.ts
@@ -18,7 +18,7 @@ export async function getProjectMeta(context: vscode.ExtensionContext) {
   const metaJson = await vscode.workspace.fs.readFile(metaUri);
   if (!metaJson) {
     vscode.window.showErrorMessage(
-      'Versification not found. Please open valid audio workspace or creare new audio project',
+      'Audio metadata not found. Please open valid audio workspace or create new audio project',
     );
     return;
   }
@@ -26,6 +26,12 @@ export async function getProjectMeta(context: vscode.ExtensionContext) {
   //   TODO : metadata need to be load on extension start and store in extension / workspace global store
 
   const parsedMeta = JSON.parse(metaJson.toString());
+
+  if (parsedMeta.type.flavorType.flavor.name === 'audioTranslation') {
+    vscode.commands.executeCommand(
+      'workbench.view.extension.audio-explorer-sidebar-view',
+    );
+  }
 
   return parsedMeta;
 }


### PR DESCRIPTION
- When opening a workspace and if the metadata is audio. Switch the menu tab to audio extension automatically - #56 
- Changed the versification reading from the hard-coded path to reading from metadata. - #59 
- Validating the flavour type, if audio then allow the user to use the extension else throws back an error of mismatching the project #60 